### PR TITLE
[LW-9203] Tuning EP's ActiveMQ instances

### DIFF
--- a/templates/activemq.xml.erb
+++ b/templates/activemq.xml.erb
@@ -116,7 +116,7 @@
 
         <% if @mq_cluster_type == "nocluster" -%>
         <persistenceAdapter>
-             <kahaDB directory="/var/activemq/kahadb"/>
+             <kahaDB directory="/var/activemq/kahadb" preallocationStrategy="zeros"/>
         </persistenceAdapter>
         <%- end -%>
 

--- a/templates/activemq.xml.erb
+++ b/templates/activemq.xml.erb
@@ -58,6 +58,14 @@
         </plugins>
         <%- end -%>
 
+        <destinationInterceptors>
+          <virtualDestinationInterceptor>
+            <virtualDestinations>
+              <virtualTopic name="VirtualTopic.>" concurrentSend="true"/>
+            </virtualDestinations>
+          </virtualDestinationInterceptor>
+        </destinationInterceptors>
+
         <destinationPolicy>
             <policyMap>
               <policyEntries>

--- a/templates/activemq.xml.erb
+++ b/templates/activemq.xml.erb
@@ -136,13 +136,13 @@
           <systemUsage>
             <systemUsage>
                 <memoryUsage>
-                    <memoryUsage percentOfJvmHeap="70" />
+                    <memoryUsage percentOfJvmHeap="75" />
                 </memoryUsage>
                 <storeUsage>
-                    <storeUsage limit="100 gb"/>
+                    <storeUsage limit="150 gb"/>
                 </storeUsage>
                 <tempUsage>
-                    <tempUsage limit="50 gb"/>
+                    <tempUsage limit="25 gb"/>
                 </tempUsage>
             </systemUsage>
         </systemUsage>


### PR DESCRIPTION
Updating the ActiveMQ configuration to tune it for increased performance. This includes:

- Using a preallocation strategy for the KahaDB to increase performance.
- Using concurrend sending of messages when processing Virtual Topics.
- Increasing slightly the threshold for when Producer Flow Control kicks in to give event replay processing more headroom.

More information can be found in the analysis issue: [LW-9121](https://lifeway.atlassian.net/browse/LW-9121)